### PR TITLE
fix: 시음노트 수정 시 기존 업로드한 이미지 보이도록 구현

### DIFF
--- a/src/_components/tasting-note/CommentAndRatingForm.tsx
+++ b/src/_components/tasting-note/CommentAndRatingForm.tsx
@@ -19,6 +19,17 @@ import { toast } from "react-toastify";
 import Rating from "./Rating";
 import TopHeaderWithButton from "./TopHeaderWithButton";
 
+async function createFileFromUrl(url: string): Promise<File> {
+  const response = await fetch(url);
+  const blob = await response.blob();
+
+  const file = new File([blob], url.split("/").pop() || "image", {
+    type: blob.type,
+  });
+
+  return file;
+}
+
 interface Inputs {
   files: File[];
 }
@@ -43,7 +54,7 @@ export default function CommentAndRatingForm({
 }: ICommentAndRatingForm) {
   const pathname = usePathname();
   const isEditMode = pathname.includes("/edit");
-  const { tastingNoteRequest } = useTastingNoteStore();
+  const { tastingNoteRequest, imageUrlList } = useTastingNoteStore();
   const tastingNoteInformationStore = useTastingNoteInformationStore();
   const {
     alcoholicDrinksDetails,
@@ -85,6 +96,24 @@ export default function CommentAndRatingForm({
     return match ? match[1] : null;
   };
   const tastingNoteId = extractIdFromPath();
+
+  useEffect(() => {
+    if (imageUrlList.length > 0) {
+      const existingImages = imageUrlList.map(async (url) => {
+        const file = await createFileFromUrl(url);
+
+        return {
+          id: crypto.randomUUID(),
+          file, // File 객체
+          url,
+        };
+      });
+
+      Promise.all(existingImages).then((images) => {
+        setImages(images);
+      });
+    }
+  }, [imageUrlList]);
 
   useEffect(() => {
     // 편집 모드일 경우 기존 comment와 rating을 초기값으로 설정
@@ -203,10 +232,12 @@ export default function CommentAndRatingForm({
           "Content-Type": "multipart/form-data",
         },
       });
-      // 로컬스토리지 비우기
 
       // 성공 시에 상세페이지로 redirect
       if (response.data.success) {
+        localStorage.removeItem("tasting-note-storage");
+        localStorage.removeItem("TastingNoteInformationStorage");
+
         const successMessage = isEditMode
           ? "시음노트 수정이 완료되었어요."
           : "시음노트 작성이 완료되었어요.";

--- a/src/_store/useTastingNoteStore.ts
+++ b/src/_store/useTastingNoteStore.ts
@@ -4,14 +4,18 @@ import { persist } from "zustand/middleware";
 
 interface TastingNoteState {
   tastingNoteRequest: ITastingNoteRequest | null;
+  imageUrlList: string[];
   setTastingNoteRequest: (data: ITastingNoteRequest) => void;
+  setImageUrlList: (urlList: string[]) => void;
 }
 
 export const useTastingNoteStore = create(
   persist<TastingNoteState>(
     (set) => ({
       tastingNoteRequest: null,
+      imageUrlList: [],
       setTastingNoteRequest: (data) => set({ tastingNoteRequest: data }),
+      setImageUrlList: (urlList) => set({ imageUrlList: urlList }), // 이미지 URL 업데이트
     }),
     {
       name: "tasting-note-storage",

--- a/src/app/(view)/(main)/share/note/[id]/edit/page.tsx
+++ b/src/app/(view)/(main)/share/note/[id]/edit/page.tsx
@@ -37,7 +37,7 @@ function EditTastingNote({ id }: IEditTastingNote) {
   const brewery = searchParams.get("brewery") ?? "";
   const breweryLocation = searchParams.get("breweryLocation") ?? "";
 
-  const { setTastingNoteRequest } = useTastingNoteStore();
+  const { setTastingNoteRequest, setImageUrlList } = useTastingNoteStore();
   const [cookies] = useCookies(["accessToken"]);
 
   const { data } = useQuery({
@@ -67,7 +67,7 @@ function EditTastingNote({ id }: IEditTastingNote) {
           type.name === data.tastingNoteDetailInfo.alcoholTypeName,
       );
 
-      const processedData: ITastingNoteWriteRequest = {
+      const requestData: ITastingNoteWriteRequest = {
         alcoholicDrinksDetails: {
           alcoholicDrinksName: data.tastingNoteDetailInfo.alcoholicDrinksName,
           alcoholContent: data.tastingNoteDetailInfo.alcoholContent,
@@ -85,9 +85,13 @@ function EditTastingNote({ id }: IEditTastingNote) {
         isPrivate: false,
         rating: data.tastingNoteDetailInfo.rating,
       };
-      setTastingNoteRequest({ request: processedData, files: [] });
+
+      const imageUrlList = data.imageInfo.imageUrlList || [];
+      setImageUrlList(imageUrlList);
+
+      setTastingNoteRequest({ request: requestData, files: [] });
     }
-  }, [data, alcoholTypeData]);
+  }, [data, alcoholTypeData, setImageUrlList, setTastingNoteRequest]);
 
   const [step, setStep] = useState<number>(1);
   const [rest, setRest] = useState<number>(4);


### PR DESCRIPTION
# 어떤 기능인가요?

> 시음노트 수정 5단계 정상 수행되도록 기존 업로드한 이미지 삭제되는 문제 해결

## 작업 상세 내용

- [x] 로컬스토리지에 기존 업로드한 이미지 url 저장
- [x] 이미지 url을 바탕으로 File 객체 생성 및 업로드

## 참고할만한 자료(선택)

- QA ID: [T2](https://docs.google.com/spreadsheets/d/1s5TlrwmV9E6Yl_5q8b6RPOzDOox_l6Ea2eh6pCGSigs/edit?gid=246987737#gid=246987737)