### PR TITLE
fix: 공유공간 작성버튼 열리지 않은 상태에서 페이지로 넘어가는 버그 수정

### DIFF
--- a/src/_components/share/FloatingBtn.tsx
+++ b/src/_components/share/FloatingBtn.tsx
@@ -12,7 +12,7 @@ export default function FloatingBtn() {
       <div
         className={cn(
           "pointer-events-none absolute inset-0 z-20 h-full w-full transition duration-200 ease-out",
-          clicked && "pointer-events-auto bg-black bg-opacity-60",
+          clicked && "pointer-events-auto bg-black bg-opacity-60"
         )}
         onClick={() => setClicked((prev) => !prev)}
       />
@@ -23,12 +23,15 @@ export default function FloatingBtn() {
           className={cn(
             "pointer-events-auto h-24 w-[143px] rounded-lg border bg-white opacity-0 transition-opacity duration-200 ease-out",
             clicked && "opacity-100",
+            !clicked && "pointer-events-none"
           )}
-          onClick={() => setClicked((prev) => !prev)}
         >
           <Link
-            href="/share/note/search"
-            className="flex h-1/2 items-center justify-center"
+            href={clicked ? "/share/note/search" : "#"}
+            className={cn(
+              "flex h-1/2 items-center justify-center",
+              !clicked && "cursor-not-allowed"
+            )}
           >
             <Image
               src="/images/icons/addingBtn/tasting.png"
@@ -41,8 +44,11 @@ export default function FloatingBtn() {
             </div>
           </Link>
           <Link
-            href="/share/life/write"
-            className="flex h-1/2 items-center justify-center"
+            href={clicked ? "/share/life/write" : "#"}
+            className={cn(
+              "flex h-1/2 items-center justify-center",
+              !clicked && "cursor-not-allowed"
+            )}
           >
             <Image
               src="/images/icons/addingBtn/dailyfeed.png"
@@ -58,7 +64,7 @@ export default function FloatingBtn() {
         <button
           className={cn(
             "pointer-events-auto flex h-12 w-12 items-center justify-center rounded-3xl bg-primary-700 shadow transition duration-200 ease-out",
-            clicked && "bg-white",
+            clicked && "bg-white"
           )}
           onClick={() => setClicked((prev) => !prev)}
         >


### PR DESCRIPTION
# 어떤 기능인가요?

기획안 : 초록색 부분(+)을 클릭하면 화면 전체가 어두어지면서 (x)로 바뀌고 [시음노트 작성]과 [일상생활 작성]이 나오고, 선택 시 해당 Depth로 넘어가야함.
버그 : 초록색 부분(+)을 클릭하지 않아도, [시음노트 작성]과 [일상생활 작성]이 존재하는 위치를 클릭하면 해당 Depth로 넘어가지는 버그가 생김.
## 작업 상세 내용

- [x] 관련 버그 수정 완료

## 참고할만한 자료(선택)
https://w1724075727-mir844192.slack.com/archives/C07HHHGB44A/p1737434462753159